### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In your actions workflow, somewhere after the step that builds
 
 ```bash
 - name: Deploy service to Cloud Run
-  uses: stefda/action-cloud-run@1.0.0
+  uses: stefda/action-cloud-run@v1.0
   with:
     image: gcr.io/[your-project]/[image]
     service: [your-service]


### PR DESCRIPTION
`uses: stefda/action-cloud-run@1.0.0` fails with the error message

> ##[warning]Failed to download action 'https://api.github.com/repos/stefda/action-cloud-run/tarball/1.0'. Error Response status code does not indicate success: 404 (Not Found).

See https://github.com/TylerCarberry/VergeTaglines/pull/6/checks?check_run_id=462820723