### PR TITLE
Add env to action.yml (fixes #7)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   service key:
     description: 'GCP service key with storage and run permissions'
     required: true
+  env:
+    description: 'Path to .env file which will be added to the Cloud Run deployment'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
Currently, GitHub throws a warning when you enter the env parameter because it is not defined as a correct input variable.