### PR TITLE
Fixing Over Permission that changes Cloud Run IAM to allow NoAuth

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,6 @@ gcloud run deploy "$INPUT_SERVICE" \
   --image "$INPUT_IMAGE" \
   --platform managed \
   --region "$INPUT_REGION" \
-  --allow-unauthenticated \
   ${ENV_FLAG}
 
 gcloud run services update-traffic "$INPUT_SERVICE" --to-latest \


### PR DESCRIPTION
This flag updates a GCP Projects Cloud Run Configured authentication policy to allow unauthenticated access to a cloud run service. This Github Action should  not assume IAM policies for any Cloud Run Action, rather instead trust that the service account provided has proper access to deploy to Cloud Run