### PR TITLE
Don't push image into registry as part of the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An GitHub Action for deploying revisions to Google Cloud Run.
 
+## v2 breaking changes
+
+Version 2 assumes that the deployed image is already pushed into Container Registry.
+
 ## Usage
 
 In your actions workflow, somewhere after the step that builds

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,9 +29,6 @@ then
 fi
 
 gcloud auth activate-service-account --key-file="$HOME"/gcloud.json --project "$INPUT_PROJECT"
-gcloud auth configure-docker
-
-docker push "$INPUT_IMAGE"
 
 gcloud run deploy "$INPUT_SERVICE" \
   --image "$INPUT_IMAGE" \


### PR DESCRIPTION
This will allow for splitting the action into a separate job that doesn't rely on the image being available in the job context.